### PR TITLE
Fix --message-format flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,7 @@ export async function run(actionInput: input.Input): Promise<Result<void, string
             'cargo',
             [
                 'clippy',
-                '--message=format=json',
+                '--message-format=json',
                 ...actionInput.options.filter(opt => !opt.startsWith('--message-format')),
                 '--',
                 ...warn,


### PR DESCRIPTION
The `--message-format` had a `=` instead of `-`, it is now fixed.